### PR TITLE
add glob package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "cf-pagination": "latest",
     "cf-tables": "latest",
     "cf-typography": "latest",
+    "glob": "7.0.5",
     "highlight.js": "9.4.0",
     "html5shiv": "latest"
   },


### PR DESCRIPTION
glob is required to run npm start by some other dependency. without this fix you get install + npm start errors
