### PR TITLE
Updated styles watch task to watch any symlinked CF components

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -83,6 +83,7 @@ module.exports = {
       dest: loc.dist + '/static/js/'
     }
   },
+  components: glob.sync( loc.lib + '/cf-*' ),
   usage: {
     files: {
       src: [

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -7,10 +7,15 @@
 
 var gulp = require( 'gulp' );
 var config = require( '../config' );
+var stylesArr = [ config.styles.cwd + '/**/*.less' ];
+
+config.components.forEach( function( src, index ) {
+  stylesArr.push( src + '/**/*.less' );
+} );
 
 gulp.task( 'watch', [ 'browserSync' ], function() {
   gulp.watch( config.scripts.src, [ 'scripts' ] );
-  gulp.watch( config.styles.cwd + '/**/*.less', [ 'styles' ] );
+  gulp.watch( stylesArr, [ 'styles' ] );
   gulp.watch( config.images.src, [ 'images' ] );
   gulp.watch( config.copy.files.src, [ 'copy:files' ] );
 } );


### PR DESCRIPTION
When updating a component in the capital-framework repo this project could not detect the change and users had to kick off the build process manually. Updated the watch task to include each less file from each component so that changes can be detected. It still requires a manual browser refresh, but that seems to be an outside issue.
## Changes
- Added components array to gulp config
- Updated watch task to combine components and main stylesheet
## Testing
- Link a cf component to the project
- run `npm start` within the project
- make a change to the source of the linked component, watch the terminal update
- refresh browser, changes should be visible.
## Review
- @KimberlyMunoz 
- @cfarm 
## Todos
- Gulp is refreshing the browser, but the changes only seem to show up after a manual refresh.
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [ ] Passes all existing automated tests
- [ ] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged
- [x] Visually tested in supported browsers and devices 
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
