### PR TITLE
Added `npm run build` script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,14 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
+
+### Added
+
+- Added documentation files to include all components
+- Added glob package
+- Added npm build script to standardize building across projects
+
+### Changed
+
+- Updated gulp watch task to watch CF components in node_modules dir
+- Updated instructions for bundler installation

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "url": "http://consumerfinance.gov"
   },
   "scripts": {
-    "start": "parallelshell 'bundle exec jekyll serve --watch --baseurl ''' 'gulp watch'"
+    "start": "parallelshell 'bundle exec jekyll serve --watch --baseurl ''' 'gulp watch'",
+    "build": "gulp build"
   },
   "license": "CC0",
   "keywords": [


### PR DESCRIPTION
To avoid confusion from each project having a slightly differing build system, adding an npm script to make it consistent.
## Additions
- build script
## Testing
- run `npm run build` and check that the project's asset files are built
## Review
- @KimberlyMunoz 
- @contolini 

[Preview this PR without the whitespace changes](?w=0)
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [x] Passes all existing automated tests
- [x] New functions include new tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged
- [x] Visually tested in supported browsers and devices
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
